### PR TITLE
chore(release): v1.1.3 — registry-prep + max_tokens default 10000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `@orcarouter/mcp` follow the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.3
+
+### Changed
+
+- **Default `max_tokens` for `orcarouter_chat` raised from 2000 to 10000.**
+  The previous 2000-token cap was conservative and truncated typical
+  long-form completions (code generation, multi-paragraph summaries).
+  Callers who explicitly set `max_tokens` are unaffected. Reasoning
+  models still receive the value via `max_completion_tokens` at the
+  wire as before.
+
+### Added
+
+- **`mcpName` field in `package.json` and a `server.json` manifest** to
+  support publishing to the [MCP Registry](https://registry.modelcontextprotocol.io/).
+  Server name: `io.github.Continuum-AI-Corp/orcarouter-mcp`. No runtime
+  behavior change — registry-discovery metadata only.
+
 ## v1.1.2
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@orcarouter/mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
+  "mcpName": "io.github.Continuum-AI-Corp/orcarouter-mcp",
   "description": "Official Model Context Protocol server for OrcaRouter — an OpenAI-compatible LLM API gateway.",
   "license": "MIT",
   "author": "OrcaRouter",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Continuum-AI-Corp/orcarouter-mcp",
+  "title": "OrcaRouter",
+  "description": "Browse 50+ LLM providers and live pricing from inside Claude, Cursor, or any MCP client — no API key required for catalog tools. Add a key to route chat completions through the OrcaRouter gateway with automatic fallback.",
+  "websiteUrl": "https://orcarouter.ai",
+  "repository": {
+    "url": "https://github.com/Continuum-AI-Corp/orcarouter-mcp-server",
+    "source": "github"
+  },
+  "version": "1.1.3",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@orcarouter/mcp",
+      "version": "1.1.3",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ORCAROUTER_API_KEY",
+          "description": "OrcaRouter API key. Required only for orcarouter_chat. Catalog tools (orcarouter_models_list, orcarouter_model_card, orcarouter_providers_list) work without it.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "ORCAROUTER_BASE_URL",
+          "description": "Override the gateway base URL. Defaults to https://api.orcarouter.ai.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "ORCAROUTER_REQUEST_TIMEOUT",
+          "description": "Per-request timeout in seconds. Defaults to 300 (5 minutes) to accommodate long reasoning-model completions.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -34,7 +34,7 @@ interface ChatCompletionResponse {
 
 const DEFAULT_MODEL = "orcarouter/auto";
 const DEFAULT_TEMPERATURE = 0.7;
-const DEFAULT_MAX_TOKENS = 2000;
+const DEFAULT_MAX_TOKENS = 10000;
 
 // OpenAI's reasoning-model line (gpt-5 / o-series) rejects `max_tokens` and
 // instead requires `max_completion_tokens` on the wire. This SDK-side helper
@@ -106,7 +106,7 @@ export const chatTool: ToolDefinition<ChatInput> = {
         type: "integer",
         default: DEFAULT_MAX_TOKENS,
         description:
-          "Maximum tokens to generate (default 2000). Automatically " +
+          "Maximum tokens to generate (default 10000). Automatically " +
           "translated to max_completion_tokens for OpenAI reasoning models.",
       },
       temperature: {
@@ -203,7 +203,7 @@ export const chatTool: ToolDefinition<ChatInput> = {
     }
 
     // ------------------------------------------------------------------
-    // Apply defaults: temperature=0.7, max_tokens=2000. max_tokens is
+    // Apply defaults: temperature=0.7, max_tokens=10000. max_tokens is
     // routed to max_completion_tokens at the wire for reasoning models.
     // ------------------------------------------------------------------
     const effectiveTemperature =

--- a/test/tools/chat.test.ts
+++ b/test/tools/chat.test.ts
@@ -129,7 +129,7 @@ describe("orcarouter_chat", () => {
   });
 
   // ---------------------------------------------------------------------
-  // defaults: temperature 0.7, max_tokens 2000
+  // defaults: temperature 0.7, max_tokens 10000
   // ---------------------------------------------------------------------
 
   it("default temperature 0.7 when omitted", async () => {
@@ -139,11 +139,11 @@ describe("orcarouter_chat", () => {
     expect(c.body.temperature).toBe(0.7);
   });
 
-  it("default max_tokens 2000 when omitted", async () => {
+  it("default max_tokens 10000 when omitted", async () => {
     const c = captureBody();
     const client = new ApiClient({ apiKey: "k", baseUrl: BASE });
     await chatTool.handler({ model: "x", prompt: "hi" }, { client });
-    expect(c.body.max_tokens).toBe(2000);
+    expect(c.body.max_tokens).toBe(10000);
   });
 
   it("explicit max_tokens forwarded", async () => {
@@ -210,7 +210,7 @@ describe("orcarouter_chat", () => {
       { model: "openai/gpt-5", prompt: "hi" },
       { client },
     );
-    expect(c.body.max_completion_tokens).toBe(2000);
+    expect(c.body.max_completion_tokens).toBe(10000);
     expect("max_tokens" in c.body).toBe(false);
   });
 
@@ -232,7 +232,7 @@ describe("orcarouter_chat", () => {
       { model: "openai/o3-pro", prompt: "hi" },
       { client },
     );
-    expect(c.body.max_completion_tokens).toBe(2000);
+    expect(c.body.max_completion_tokens).toBe(10000);
     expect("max_tokens" in c.body).toBe(false);
   });
 
@@ -243,7 +243,7 @@ describe("orcarouter_chat", () => {
       { model: "openai/o4", prompt: "hi" },
       { client },
     );
-    expect(c.body.max_completion_tokens).toBe(2000);
+    expect(c.body.max_completion_tokens).toBe(10000);
     expect("max_tokens" in c.body).toBe(false);
   });
 
@@ -254,7 +254,7 @@ describe("orcarouter_chat", () => {
       { model: "openai/gpt-4o-mini", prompt: "hi" },
       { client },
     );
-    expect(c.body.max_tokens).toBe(2000);
+    expect(c.body.max_tokens).toBe(10000);
     expect("max_completion_tokens" in c.body).toBe(false);
   });
 
@@ -265,7 +265,7 @@ describe("orcarouter_chat", () => {
       { model: "anthropic/claude-haiku-4.5", prompt: "hi" },
       { client },
     );
-    expect(c.body.max_tokens).toBe(2000);
+    expect(c.body.max_tokens).toBe(10000);
     expect("max_completion_tokens" in c.body).toBe(false);
   });
 
@@ -274,7 +274,7 @@ describe("orcarouter_chat", () => {
     const client = new ApiClient({ apiKey: "k", baseUrl: BASE });
     await chatTool.handler({ prompt: "hi" }, { client });
     expect(c.body.model).toBe("orcarouter/auto");
-    expect(c.body.max_tokens).toBe(2000);
+    expect(c.body.max_tokens).toBe(10000);
     expect("max_completion_tokens" in c.body).toBe(false);
   });
 
@@ -283,7 +283,7 @@ describe("orcarouter_chat", () => {
     const client = new ApiClient({ apiKey: "k", baseUrl: BASE });
     await chatTool.handler({ model: "gpt-5", prompt: "hi" }, { client });
     expect(c.body.model).toBe("gpt-5");
-    expect(c.body.max_completion_tokens).toBe(2000);
+    expect(c.body.max_completion_tokens).toBe(10000);
     expect("max_tokens" in c.body).toBe(false);
   });
 
@@ -469,7 +469,7 @@ describe("orcarouter_chat", () => {
       { default?: unknown }
     >;
     expect(props.model.default).toBe("orcarouter/auto");
-    expect(props.max_tokens.default).toBe(2000);
+    expect(props.max_tokens.default).toBe(10000);
     expect(props.temperature.default).toBe(0.7);
   });
 


### PR DESCRIPTION
## Summary

- **Default `max_tokens` for `orcarouter_chat` raised from 2000 → 10000.** The previous cap truncated typical long-form completions (code generation, multi-paragraph summaries). Explicit callers are unaffected. Reasoning models still get the value via `max_completion_tokens` at the wire as before.
- **Add `mcpName` field + `server.json` manifest** so we can publish to the [MCP Registry](https://registry.modelcontextprotocol.io/) under `io.github.Continuum-AI-Corp/orcarouter-mcp`. No runtime behavior change — registry-discovery metadata only.
- Version bump to **1.1.3**, CHANGELOG updated.

## Files changed

- `src/tools/chat.ts` — `DEFAULT_MAX_TOKENS` constant + docstring + comment (2000 → 10000)
- `test/tools/chat.test.ts` — all default-related assertions updated; explicit-value tests untouched (115/115 passing)
- `package.json` — `version` 1.1.2 → 1.1.3, added `mcpName: "io.github.Continuum-AI-Corp/orcarouter-mcp"`
- `server.json` — new file, MCP Registry manifest with env-var declarations
- `CHANGELOG.md` — v1.1.3 entry

## Verification done locally

- [x] `npm run typecheck` — clean
- [x] `npm test` — 115/115 passing
- [x] `npm run build` — succeeds (dist/index.js 23.86 KB)

## Test plan

- [ ] Reviewer: confirm `server.json` env-var list matches what users actually need (workspace var intentionally omitted — source doesn't read `ORCAROUTER_WORKSPACE_ID`)
- [ ] After merge: bump `npm publish --access public` from `main`
- [ ] After npm publish: `mcp-publisher login github` (as a `Continuum-AI-Corp` org member) then `mcp-publisher publish`
- [ ] Verify with `curl 'https://registry.modelcontextprotocol.io/v0.1/servers?search=orcarouter'`

## Notes

`mcpName` namespace `io.github.Continuum-AI-Corp/...` requires the registry publisher to log in via GitHub as a member of the `Continuum-AI-Corp` org. DNS-based namespace (e.g. `ai.orcarouter/mcp`) is a possible future migration once we want a branded namespace.