### PR TITLE
ci: auto-publish to npm + MCP Registry on version tags

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,8 +56,17 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish --access public
+      # Idempotent publish: skip if the exact version is already on npm so that
+      # a partial failure later in this job (e.g. transient mcp-publisher
+      # error) can be recovered by a plain "Re-run failed jobs" without
+      # tripping over npm's "version already exists" rejection.
+      - name: Publish to npm (idempotent)
+        run: |
+          if npm view "@orcarouter/mcp@${VERSION}" version >/dev/null 2>&1; then
+            echo "@orcarouter/mcp@${VERSION} already on npm — skipping publish"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -70,5 +79,16 @@ jobs:
       - name: Authenticate to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc
 
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+      # Idempotent publish: skip if this exact version is already in the
+      # registry, for the same rerun-safety reason as the npm step above.
+      - name: Publish to MCP Registry (idempotent)
+        run: |
+          MCP_NAME=$(jq -r '.name' server.json)
+          EXISTING=$(curl -sf "https://registry.modelcontextprotocol.io/v0/servers?search=${MCP_NAME}" \
+            | jq -r --arg n "$MCP_NAME" --arg v "$VERSION" \
+                '.servers[]?.server | select(.name == $n and .version == $v) | .name')
+          if [ -n "$EXISTING" ]; then
+            echo "${MCP_NAME}@${VERSION} already in MCP Registry — skipping publish"
+          else
+            ./mcp-publisher publish
+          fi

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -45,7 +45,11 @@ jobs:
           if [ "$MCP_NAME_PKG" != "$MCP_NAME_SRV" ]; then
             echo "::error::package.json mcpName ($MCP_NAME_PKG) != server.json name ($MCP_NAME_SRV)"; fail=1
           fi
-          exit $fail
+          if [ "$fail" -ne 0 ]; then exit "$fail"; fi
+
+          # Export the validated version so later steps (publish idempotency
+          # checks, version-pinned mcp-publisher inputs, etc.) can read it.
+          echo "VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,74 @@
+name: Publish to npm and MCP Registry
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  id-token: write   # required for GitHub OIDC → MCP Registry
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate tag matches package.json and server.json
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          SRV_VERSION=$(jq -r '.version' server.json)
+          SRV_PKG_VERSION=$(jq -r '.packages[0].version' server.json)
+          MCP_NAME_PKG=$(node -p "require('./package.json').mcpName")
+          MCP_NAME_SRV=$(jq -r '.name' server.json)
+
+          fail=0
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION != package.json version $PKG_VERSION"; fail=1
+          fi
+          if [ "$TAG_VERSION" != "$SRV_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION != server.json version $SRV_VERSION"; fail=1
+          fi
+          if [ "$TAG_VERSION" != "$SRV_PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION != server.json packages[0].version $SRV_PKG_VERSION"; fail=1
+          fi
+          if [ "$MCP_NAME_PKG" != "$MCP_NAME_SRV" ]; then
+            echo "::error::package.json mcpName ($MCP_NAME_PKG) != server.json name ($MCP_NAME_SRV)"; fail=1
+          fi
+          exit $fail
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --help | head -1
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-mcp.yml` that fully automates releases. After this lands, the publish dance we did manually for v1.1.3 collapses into a `git tag && git push`.

## How releases work after this

```bash
# 1. Open a release PR that bumps:
#    - package.json: version
#    - server.json: version + packages[0].version
#    - CHANGELOG.md
# 2. Merge the PR
# 3. Tag the merge commit:
git tag v1.1.4
git push origin v1.1.4
# 4. CI does everything: typecheck → test → build → npm publish → mcp-publisher publish
```

## Pipeline (in order)

1. `actions/checkout@v5` + `actions/setup-node@v5`
2. `npm ci`
3. **Version drift check** — fails the build if any of these don't match:
   - git tag (`v1.1.4`)
   - `package.json` `version`
   - `server.json` `version`
   - `server.json` `packages[0].version`
   - Also asserts `package.json.mcpName == server.json.name`
4. `npm run typecheck`
5. `npm test`
6. `npm run build`
7. `npm publish --access public` (uses `NPM_TOKEN` secret)
8. Install `mcp-publisher` CLI from latest release
9. `mcp-publisher login github-oidc` (uses GitHub OIDC, no secret)
10. `mcp-publisher publish`

## Authentication

| What | How | Setup |
|---|---|---|
| npm publish | `NODE_AUTH_TOKEN` from `NPM_TOKEN` secret | **You must add this once** |
| MCP Registry | GitHub OIDC (`id-token: write` permission) | No secret needed — works because we're publishing from a repo under `Continuum-AI-Corp` org to the matching `io.github.Continuum-AI-Corp/...` namespace |

## Required setup before this can run

Add an `NPM_TOKEN` secret to the repo:

1. Generate an npm Automation token at https://www.npmjs.com/settings/<your-npm-user>/tokens (choose **Automation** type so 2FA-on-publish doesn't block CI)
2. Add it as a repo secret named `NPM_TOKEN` at `https://github.com/Continuum-AI-Corp/orcarouter-mcp-server/settings/secrets/actions`

The OIDC side needs no setup — it works out of the box because:
- Our `mcpName` is `io.github.Continuum-AI-Corp/orcarouter-mcp`
- The workflow runs in a repo under `Continuum-AI-Corp` org
- registry.modelcontextprotocol.io validates the `repository_owner` OIDC claim matches the namespace

## Why the drift check matters

It catches the most common release-PR mistake: bumping `package.json` but forgetting to bump `server.json` (or vice versa). The MCP Registry would reject a mismatched publish anyway, but failing in CI before `npm publish` runs prevents shipping an orphaned npm version.

## Out of scope

- Auto-bumping versions from the tag (kept manual to keep the release PR as the source of truth)
- CHANGELOG validation (could add later — check the new tag has a matching entry)
- Auto-PR creation for version bumps (future improvement)

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Reviewer: confirm `NPM_TOKEN` secret will be added before merging
- [ ] After merge, dry-run by tagging a no-op `v1.1.3-test` (or whatever) on a feature branch and inspecting CI output — actually, since `npm publish` would 409 on the existing v1.1.3, the safer way to dry-run is to wait for the real next release (v1.1.4) and watch closely