### PR TITLE
feat: add .mcp.json (Open Plugins manifest) for cursor.directory auto-detect

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "orcarouter": {
+      "command": "npx",
+      "args": ["-y", "@orcarouter/mcp"],
+      "env": {
+        "ORCAROUTER_API_KEY": "sk-or-..."
+      }
+    }
+  }
+}

--- a/README.de.md
+++ b/README.de.md
@@ -72,6 +72,8 @@ claude mcp add orcarouter -s user \
 2. Ersetze `sk-or-...` in der kopierten Datei durch deinen [OrcaRouter API-Schlüssel](https://www.orcarouter.ai/console).
 3. Starte deinen MCP-Client neu.
 
+Die [`.mcp.json`](.mcp.json) im Stammverzeichnis enthält dieselbe Konfiguration am Standardort von [Open Plugins](https://open-plugins.com), sodass Registry- und Discovery-Tools, die danach suchen (z. B. [cursor.directory](https://cursor.directory)), diesen Server automatisch erkennen können.
+
 Erfordert Node.js 18 oder höher. Die Umgebungsvariable `ORCAROUTER_API_KEY` wird nur für `orcarouter_chat` benötigt; die Katalog-Tools funktionieren auch ohne sie.
 
 ## Tools

--- a/README.es.md
+++ b/README.es.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Reemplaza `sk-or-...` en el archivo copiado con tu [clave de API de OrcaRouter](https://www.orcarouter.ai/console).
 3. Reinicia tu cliente MCP.
 
+El [`.mcp.json`](.mcp.json) en la raíz es la misma configuración en la ubicación estándar de [Open Plugins](https://open-plugins.com), de modo que las herramientas de registro/descubrimiento que lo escanean (por ejemplo, [cursor.directory](https://cursor.directory)) pueden detectar este servidor automáticamente.
+
 Requiere Node.js 18 o superior. La variable de entorno `ORCAROUTER_API_KEY` solo
 es necesaria para `orcarouter_chat`; las herramientas del catálogo funcionan sin ella.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Remplacez `sk-or-...` dans le fichier copié par votre [clé API OrcaRouter](https://www.orcarouter.ai/console).
 3. Redémarrez votre client MCP.
 
+Le [`.mcp.json`](.mcp.json) à la racine est la même configuration à l'emplacement standard d'[Open Plugins](https://open-plugins.com), ce qui permet aux outils de registre/découverte qui l'analysent (par exemple [cursor.directory](https://cursor.directory)) de détecter ce serveur automatiquement.
+
 Node.js 18 ou ultérieur est requis. La variable d'environnement `ORCAROUTER_API_KEY`
 n'est nécessaire que pour `orcarouter_chat` ; les outils de catalogue fonctionnent sans elle.
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. कॉपी की गई file में `sk-or-...` को अपनी [OrcaRouter API key](https://www.orcarouter.ai/console) से बदलें।
 3. अपना MCP client पुनः प्रारंभ करें।
 
+रूट में स्थित [`.mcp.json`](.mcp.json) [Open Plugins](https://open-plugins.com) मानक स्थान पर वही कॉन्फ़िगरेशन है, जिससे इसे स्कैन करने वाले registry/discovery tools (जैसे [cursor.directory](https://cursor.directory)) इस server को स्वचालित रूप से पहचान सकें।
+
 Node.js 18 या उसके बाद का संस्करण आवश्यक है। `ORCAROUTER_API_KEY` env var केवल
 `orcarouter_chat` के लिए आवश्यक है; catalog tools इसके बिना काम करते हैं।
 

--- a/README.it.md
+++ b/README.it.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Sostituisci `sk-or-...` nel file copiato con la tua [chiave API OrcaRouter](https://www.orcarouter.ai/console).
 3. Riavvia il tuo client MCP.
 
+Il [`.mcp.json`](.mcp.json) nella radice è la stessa configurazione nella posizione standard di [Open Plugins](https://open-plugins.com), così gli strumenti di registry/scoperta che la scansionano (ad es. [cursor.directory](https://cursor.directory)) possono rilevare automaticamente questo server.
+
 Richiede Node.js 18 o successivo. La variabile d'ambiente `ORCAROUTER_API_KEY`
 è necessaria solo per `orcarouter_chat`; gli strumenti di catalogo funzionano
 senza di essa.

--- a/README.ja.md
+++ b/README.ja.md
@@ -74,6 +74,8 @@ claude mcp add orcarouter -s user \
 2. コピーしたファイル内の `sk-or-...` をあなたの [OrcaRouter API key](https://www.orcarouter.ai/console) に置き換えます。
 3. MCP クライアントを再起動します。
 
+ルートの [`.mcp.json`](.mcp.json) は [Open Plugins](https://open-plugins.com) 標準の場所に置かれた同じ設定です。これにより、このファイルをスキャンするレジストリ/ディスカバリーツール（例: [cursor.directory](https://cursor.directory)）が本サーバーを自動的に検出できます。
+
 Node.js 18 以降が必要です。`ORCAROUTER_API_KEY` 環境変数は
 `orcarouter_chat` でのみ必要で、カタログ系ツールはこれなしで動作します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -72,6 +72,8 @@ claude mcp add orcarouter -s user \
 2. 복사한 파일에서 `sk-or-...`를 본인의 [OrcaRouter API key](https://www.orcarouter.ai/console)로 교체합니다.
 3. MCP 클라이언트를 재시작합니다.
 
+루트의 [`.mcp.json`](.mcp.json)은 [Open Plugins](https://open-plugins.com) 표준 위치에 있는 동일한 구성으로, 이 파일을 스캔하는 레지스트리/디스커버리 도구(예: [cursor.directory](https://cursor.directory))가 이 서버를 자동으로 인식할 수 있습니다.
+
 Node.js 18 이상이 필요합니다. `ORCAROUTER_API_KEY` 환경 변수는 `orcarouter_chat`에만 필요하며, 카탈로그 도구는 키 없이도 작동합니다.
 
 ## 도구

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Replace `sk-or-...` in the copied file with your [OrcaRouter API key](https://www.orcarouter.ai/console).
 3. Restart your MCP client.
 
+The root [`.mcp.json`](.mcp.json) is the same config in the [Open Plugins](https://open-plugins.com) standard location, so registry/discovery tools that scan for it (e.g. [cursor.directory](https://cursor.directory)) can pick this server up automatically.
+
 Requires Node.js 18 or later. The `ORCAROUTER_API_KEY` env var is only
 required for `orcarouter_chat`; catalog tools work without it.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Substitua `sk-or-...` no arquivo copiado pela sua [chave de API do OrcaRouter](https://www.orcarouter.ai/console).
 3. Reinicie o seu cliente MCP.
 
+O [`.mcp.json`](.mcp.json) na raiz é a mesma configuração no local padrão do [Open Plugins](https://open-plugins.com), de modo que ferramentas de registro/descoberta que o escaneiem (por exemplo, [cursor.directory](https://cursor.directory)) podem detectar este servidor automaticamente.
+
 Requer Node.js 18 ou superior. A variável de ambiente `ORCAROUTER_API_KEY` é
 necessária apenas para `orcarouter_chat`; as ferramentas de catálogo funcionam sem ela.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Замените `sk-or-...` в скопированном файле на ваш [ключ OrcaRouter API](https://www.orcarouter.ai/console).
 3. Перезапустите MCP-клиент.
 
+Файл [`.mcp.json`](.mcp.json) в корне репозитория — та же конфигурация в стандартном расположении [Open Plugins](https://open-plugins.com), благодаря чему инструменты реестра/обнаружения, которые его сканируют (например, [cursor.directory](https://cursor.directory)), могут автоматически распознать этот сервер.
+
 Требуется Node.js 18 или новее. Переменная окружения `ORCAROUTER_API_KEY` нужна
 только для `orcarouter_chat`; инструменты каталога работают и без неё.
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -76,6 +76,8 @@ claude mcp add orcarouter -s user \
 2. Thay `sk-or-...` trong file đã sao chép bằng [API key OrcaRouter](https://www.orcarouter.ai/console) của bạn.
 3. Khởi động lại client MCP của bạn.
 
+File [`.mcp.json`](.mcp.json) ở thư mục gốc là cùng cấu hình tại vị trí chuẩn của [Open Plugins](https://open-plugins.com), giúp các công cụ registry/khám phá quét nó (ví dụ [cursor.directory](https://cursor.directory)) có thể tự động nhận diện server này.
+
 Yêu cầu Node.js 18 trở lên. Biến môi trường `ORCAROUTER_API_KEY` chỉ
 bắt buộc cho `orcarouter_chat`; các công cụ danh mục hoạt động mà không cần nó.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,6 +74,8 @@ claude mcp add orcarouter -s user \
 2. 将复制文件中的 `sk-or-...` 替换为你的 [OrcaRouter API key](https://www.orcarouter.ai/console)。
 3. 重启你的 MCP 客户端。
 
+根目录的 [`.mcp.json`](.mcp.json) 是符合 [Open Plugins](https://open-plugins.com) 标准位置的同一份配置，让扫描该文件的注册/发现工具（如 [cursor.directory](https://cursor.directory)）能自动识别本 server。
+
 需要 Node.js 18 或更高版本。`ORCAROUTER_API_KEY` 环境变量仅在使用
 `orcarouter_chat` 时必填；目录类工具无需 API key 即可使用。
 


### PR DESCRIPTION
## Why

[cursor.directory](https://cursor.directory)'s auto-submit scans for an Open Plugins manifest at the repo root. Without it, the form falls back to manual entry and won't auto-list us.

The error from their scanner:

> No plugin components found in: repo root. We looked for: rules/\*.mdc, .mcp.json or mcp.json, skills/\*/SKILL.md, agents/\*.md, commands/\*.md, hooks/hooks.json, .lsp.json.

Adding `.mcp.json` is the lightest-touch way to make us discoverable by Open Plugins-aware tooling (cursor.directory today; other registries are likely to follow since this is becoming the standard).

## What changed

| File | Change |
|---|---|
| `.mcp.json` | New file. Identical schema to `examples/cursor.json` — same `mcpServers` block users already consume in Claude Desktop / Cursor / Windsurf. Just placed at the standard discovery location. |
| `README.md` | One sentence pointing at `.mcp.json` and explaining its role, so contributors don't accidentally delete it thinking it's stray. |

## Why not just rely on `examples/cursor.json`

`examples/` is for humans (copy → paste into client config). `.mcp.json` at repo root is for machines (registry scanners, plugin hosts, etc.) — the [Open Plugins](https://open-plugins.com) standard defines this exact filename + location. Different audiences, both needed.

## Test plan

- [x] `jq . .mcp.json` parses clean
- [ ] After merge: re-run cursor.directory's "Scan repo" on https://cursor.directory/plugins/new — should now detect us and pre-fill the form
- [ ] (Optional) Drop the file's contents into `~/.cursor/mcp.json` locally, restart Cursor, ask "list orcarouter models" — should invoke `orcarouter_models_list`. Equivalent test was already done via `npx @modelcontextprotocol/inspector` earlier; this is just the user-facing path.