### PR TITLE
feat: add glama.json for Glama maintainer verification

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["fengyat"]
+}


### PR DESCRIPTION
## Why

Per the Glama score page, our server's profile completion is **17%** because it has no Glama release. To enable full quality scoring (Server Coherence + Tool Definition Quality), we need to:

1. Claim the server on Glama
2. Configure a Dockerfile build via Glama's admin UI
3. Make a Glama release

For an org-owned repo, step 1 requires a \`glama.json\` at the repo root that lists the maintainer's GitHub username, so Glama can verify the claiming user is authorized.

## What's in the file

```json
{
  "\$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["fengyat"]
}
```

That's it — metadata only, no runtime / build effect.

## Test plan

- [x] \`jq .\` parses
- [ ] After merge, go to https://glama.ai/mcp/servers/Continuum-AI-Corp/orcarouter-mcp-server, sign in as \`fengyat\`, click Claim, verify Glama recognizes the verified maintainer
- [ ] Then proceed with admin → Dockerfile → Deploy → Make Release