### PR TITLE
chore(release): v1.1.4 — MCP annotations + tool description polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `@orcarouter/mcp` follow the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.4
+
+### Added
+
+- **MCP `annotations` on every tool** (`readOnlyHint`, `destructiveHint`,
+  `idempotentHint`, `openWorldHint`, `title`). MCP clients can now reason
+  about each tool before they call it — e.g. render a "read-only, safe to
+  call" badge on the three catalog tools, or route the chat tool through
+  an approval workflow. Lifts Glama's `Tool Definition Quality → Behavior`
+  dimension across all four tools.
+
+### Changed
+
+- **Tool descriptions tightened** for the dimensions where Glama's TDQS
+  reviewer flagged gaps:
+  - `orcarouter_chat`: explains the `models` fallback chain interaction
+    with the primary `model`, the error surface (`isError:true` text),
+    and that ORCAROUTER_API_KEY is required.
+  - `orcarouter_model_card`: explains when to use it vs.
+    `orcarouter_models_list`, and that errors return `isError:true`.
+  - `orcarouter_models_list`: enumerates the returned fields and notes
+    that filters compose (all conditions must match).
+  - `orcarouter_providers_list`: enumerates the returned fields and
+    states the call pattern (zero-arg, idempotent).
+- No behavior change — the wire-level response shapes are unchanged.
+
 ## v1.1.3
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "mcpName": "io.github.Continuum-AI-Corp/orcarouter-mcp",
   "description": "Official Model Context Protocol server for OrcaRouter — an OpenAI-compatible LLM API gateway.",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/Continuum-AI-Corp/orcarouter-mcp-server",
     "source": "github"
   },
-  "version": "1.1.3",
+  "version": "1.1.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@orcarouter/mcp",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,6 +90,7 @@ export function createOrcaRouterMcpServer(opts: CreateServerOptions = {}): Built
         name: t.name,
         description: t.description,
         inputSchema: t.inputSchema,
+        ...(t.annotations ? { annotations: t.annotations } : {}),
       })),
     };
   });

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -77,11 +77,26 @@ function stringifyContent(content: unknown): string {
 export const chatTool: ToolDefinition<ChatInput> = {
   name: "orcarouter_chat",
   description:
-    "Send a single-turn chat request to OrcaRouter. Default model is the " +
-    "workspace's auto-router. Use `orcarouter/<name>` for other routers or " +
-    "`<provider>/<model>` for direct calls. For OpenAI reasoning models " +
-    "(gpt-5/o1/o3/...), max_tokens is automatically routed to " +
-    "max_completion_tokens at the wire level.",
+    "Send a single-turn chat request to OrcaRouter and return the assistant's " +
+    "response text. Default model is the workspace's auto-router. Use " +
+    "`orcarouter/<name>` for other routers or `<provider>/<model>` for direct " +
+    "calls. For OpenAI reasoning models (gpt-5/o1/o3/...), max_tokens is " +
+    "automatically routed to max_completion_tokens at the wire level. The " +
+    "optional `models` array sets a fallback chain — the primary `model` is " +
+    "tried first, then each entry on failure (5 entries total max, including " +
+    "the primary). Errors are returned as text content with isError:true; " +
+    "common cases include missing API key, rate limits, and upstream provider " +
+    "outages. Requires ORCAROUTER_API_KEY.",
+  annotations: {
+    title: "OrcaRouter Chat",
+    // Calls an external LLM, so not read-only and contacts an open world.
+    // Not destructive (no state mutation on our side or the provider's), but
+    // not idempotent either: the same prompt produces a different completion.
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/model_card.ts
+++ b/src/tools/model_card.ts
@@ -63,7 +63,23 @@ function errorResult(text: string): McpToolResult {
 export const modelCardTool: ToolDefinition<ModelCardInput> = {
   name: "orcarouter_model_card",
   description:
-    "Get detailed information about a single model: pricing, context window, supported endpoints, latency.",
+    "Get detailed information about a single model — display name, long " +
+    "description, pricing (per-call and per-million tokens), context window, " +
+    "max output, modalities (input/output), supported endpoints, latency " +
+    "percentiles (p50/p95), and release date. Use this when you already know " +
+    "the model id and want full details; for browsing or filtering across " +
+    "many models use orcarouter_models_list instead. Returns isError:true " +
+    "with a clear hint when the id is not found. Read-only, no API key " +
+    "required.",
+  annotations: {
+    title: "OrcaRouter Model Card",
+    // Single-model lookup against the public catalog. Read-only, deterministic
+    // for a given id, contacts the OrcaRouter API (open world), no mutation.
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/models_list.ts
+++ b/src/tools/models_list.ts
@@ -42,8 +42,23 @@ interface ModelsListResponse {
 export const modelsListTool: ToolDefinition<ModelsListInput> = {
   name: "orcarouter_models_list",
   description:
-    "List available LLM models. Filter by provider, capability, or minimum " +
-    "context length — filters are applied server-side by the OrcaRouter backend.",
+    "List LLM models in the OrcaRouter catalog. Each entry includes id, name, " +
+    "description, owned_by, context_length, supported_endpoint_types, and " +
+    "pricing (both per-token and per-million tokens). Filter by `provider`, " +
+    "`capability`, or `min_context` — filters compose (all conditions must " +
+    "match) and are applied server-side. Discover valid provider ids first " +
+    "with orcarouter_providers_list. Returns the full catalog when called " +
+    "without filters. Read-only, no API key required.",
+  annotations: {
+    title: "Browse OrcaRouter Models",
+    // Read-only browse against the public catalog endpoint; same filters
+    // yield the same set on every call (idempotent). External call → open
+    // world, not destructive.
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/providers_list.ts
+++ b/src/tools/providers_list.ts
@@ -26,10 +26,22 @@ function errorResult(text: string): McpToolResult {
 export const providersListTool: ToolDefinition<ProvidersListInput> = {
   name: "orcarouter_providers_list",
   description:
-    "List all model providers on OrcaRouter with their model counts and " +
-    "display metadata. Works without an API key. Useful for discovering " +
-    "provider ids (e.g. 'openai', 'anthropic') to pass to " +
-    "orcarouter_models_list as the `provider` filter.",
+    "List all model providers on OrcaRouter with their `provider_id`, " +
+    "human-readable `display_name`, `icon_url`, and `model_count`. Call this " +
+    "first to discover valid provider ids (e.g. 'openai', 'anthropic', " +
+    "'google', 'qwen', 'deepseek') which you can then pass to " +
+    "orcarouter_models_list as the `provider` filter. Takes no parameters and " +
+    "returns the same list on every call until the deployment's catalog " +
+    "changes. Read-only, no API key required.",
+  annotations: {
+    title: "List OrcaRouter Providers",
+    // Zero-arg read against the public catalog endpoint. Same response each
+    // call (idempotent), contacts the OrcaRouter API (open world).
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {},

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -18,10 +18,23 @@ export interface JsonSchemaObject {
   [k: string]: unknown;
 }
 
+// Behavior hints declared on every tool (MCP spec 2025-06-18). These let
+// clients reason about a tool before they call it — e.g. show a "read-only,
+// safe to call without confirmation" badge, or route destructive operations
+// through an approval workflow. Strictly additive: the schema is untouched.
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 export interface ToolDefinition<I = unknown> {
   name: string;
   description: string;
   inputSchema: JsonSchemaObject;
+  annotations?: ToolAnnotations;
   handler: (input: I, ctx: ToolContext) => Promise<McpToolResult>;
 }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -60,6 +60,48 @@ describe("createOrcaRouterMcpServer", () => {
     await transport.close();
   });
 
+  it("tools/list response includes MCP annotations on every tool", async () => {
+    const { server: srv } = createOrcaRouterMcpServer({ apiKey: "k", baseUrl: BASE });
+    const transport = new MockTransport();
+    await srv.connect(transport);
+    const resp = await transport.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
+    interface AnnotatedTool {
+      name: string;
+      annotations?: {
+        title?: string;
+        readOnlyHint?: boolean;
+        destructiveHint?: boolean;
+        idempotentHint?: boolean;
+        openWorldHint?: boolean;
+      };
+    }
+    const tools = resp.result.tools as AnnotatedTool[];
+    // Every catalog tool is read-only + idempotent; chat alone is not.
+    const expected: Record<string, { readOnly: boolean; idempotent: boolean }> = {
+      orcarouter_chat: { readOnly: false, idempotent: false },
+      orcarouter_models_list: { readOnly: true, idempotent: true },
+      orcarouter_model_card: { readOnly: true, idempotent: true },
+      orcarouter_providers_list: { readOnly: true, idempotent: true },
+    };
+    for (const t of tools) {
+      const exp = expected[t.name];
+      expect(exp, `missing expected annotations for ${t.name}`).toBeDefined();
+      expect(t.annotations, `missing annotations on ${t.name}`).toBeDefined();
+      expect(t.annotations!.title, `missing title on ${t.name}`).toBeTruthy();
+      expect(t.annotations!.readOnlyHint).toBe(exp.readOnly);
+      expect(t.annotations!.destructiveHint).toBe(false);
+      expect(t.annotations!.idempotentHint).toBe(exp.idempotent);
+      // Every tool reaches an external service (OrcaRouter API or upstream LLM).
+      expect(t.annotations!.openWorldHint).toBe(true);
+    }
+    await transport.close();
+  });
+
   it("dispatches tools/call to the correct handler (model_card)", async () => {
     server.use(
       http.get(`${BASE}/api/public/models/openai/gpt-4o-mini`, () =>


### PR DESCRIPTION
## Why

Glama's score page flagged the same root cause across all four tools — **no MCP annotations** declared, so reviewer scoring penalizes the `Behavior` dimension (2-4 out of 5) for every tool. Sample reviewer comment from `orcarouter_model_card`:

> No annotations are present, so the description bears full burden. It indicates a read-like operation (get info) but does not explicitly state it is non-destructive, mention authorization needs, rate limits, or potential error conditions.

This PR closes that gap. It also tightens descriptions for the other low-scoring dimensions (Usage Guidelines, Completeness, Parameters).

## What changes

| File | Change |
|---|---|
| `src/tools/types.ts` | Add `ToolAnnotations` interface + optional `annotations` field on `ToolDefinition`. |
| `src/server.ts` | Pass `annotations` through to the `tools/list` response (spread `...(t.annotations ? { annotations: t.annotations } : {})`). |
| `src/tools/chat.ts` | Add `annotations` (`readOnly:false`, `idempotent:false`, `openWorld:true`) + describe `models` fallback chain interaction, `isError:true` surface, ORCAROUTER_API_KEY requirement. |
| `src/tools/models_list.ts` | Add `annotations` (`readOnly:true`, `idempotent:true`, `openWorld:true`) + enumerate returned fields + note filter composition. |
| `src/tools/model_card.ts` | Add `annotations` (read-only / idempotent / open-world) + explain when to use vs. `models_list` + note `isError:true` surface. |
| `src/tools/providers_list.ts` | Add `annotations` + enumerate returned fields + note zero-arg call shape. |
| `test/server.test.ts` | New case: `tools/list response includes MCP annotations on every tool` asserts the per-tool annotation map (4 tools × 5 fields). |
| `package.json`, `server.json` | Version bump 1.1.3 → 1.1.4. |
| `CHANGELOG.md` | v1.1.4 entry. |

## Per-tool annotations table

| Tool | readOnly | destructive | idempotent | openWorld |
|---|---|---|---|---|
| `orcarouter_chat` | F | F | F | T |
| `orcarouter_models_list` | T | F | T | T |
| `orcarouter_model_card` | T | F | T | T |
| `orcarouter_providers_list` | T | F | T | T |

Reasoning: catalog tools are read-only queries against the public OrcaRouter catalog API — same inputs give the same outputs (idempotent), and they reach an external service (open world). The chat tool reaches an external service too, but isn't read-only (it triggers an LLM completion, which the upstream provider may count, log, and bill), and isn't idempotent (same prompt produces different completions).

## What it unlocks downstream

- **Glama TDQS**: `Behavior` dimension should jump from 2-4 to ~5 across all tools. Expected overall TDQS average: 4.2 → ~4.6. Already at grade A; this firms up the score.
- **MCP clients with annotation-aware UI**: Claude Desktop, Cursor, Windsurf, etc. can render the catalog tools as "safe to call without confirmation" and the chat tool as "calls an external LLM".
- **Better LLM tool selection**: agents that consume `tools/list` get richer signal about each tool's character.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm test` — 116/116 (115 existing + 1 new annotations test)
- [x] `npm run build` — 26.51 KB ESM bundle, clean
- [x] `server.json` validates against the official MCP Registry schema

## Release plan

After merge, push the version tag and the CI auto-publish workflow (introduced in #3) takes over:

```bash
git tag v1.1.4
git push origin v1.1.4
# CI: typecheck → test → build → npm publish → mcp-publisher publish
```

Once npm + MCP Registry are updated, Glama auto-syncs from GitHub (typically within a few hours), re-runs TDQS scoring, and the new annotations land in the public score.