### PR TITLE
fix(ci): use `npm install` instead of `npm ci` in publish workflow

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -20,8 +20,13 @@ jobs:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
 
+      # Repo's primary lockfile is bun.lock (we use bun for local dev / tests),
+      # so `npm ci` rejects with "requires package-lock.json". `npm install`
+      # without a lockfile is fine here — we have a tag-gated release, deps
+      # are pinned to caret ranges in package.json that have been stable, and
+      # the build is bundled by tsup downstream. Same pattern as Dockerfile.
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Validate tag matches package.json and server.json
         run: |


### PR DESCRIPTION
## Why

The v1.1.4 tag push from a few minutes ago failed CI at the Install dependencies step:

> `npm error The \`npm ci\` command can only install with an existing package-lock.json or npm-shrinkwrap.json`

Failed run: https://github.com/Continuum-AI-Corp/orcarouter-mcp-server/actions/runs/26441777758

\`npm ci\` requires a \`package-lock.json\`. This repo uses bun as primary package manager and only commits \`bun.lock\` — no \`package-lock.json\`. PR #3 originally copied \`npm ci\` from the official MCP Registry docs example, but that example assumes an npm-managed project.

## Fix

Replace \`npm ci\` with \`npm install --no-audit --no-fund\`. Same pattern as our Dockerfile (merged in #5), which has been working against the same \`package.json\` with no issues.

## Trade-off

- ✅ Build now works without a second lockfile
- ⚠️ Transitive dep versions aren't pinned in CI. We accept this because:
  - First-level deps are pinned to caret ranges in \`package.json\` that have been stable across releases
  - tsup bundles everything into a single \`dist/index.js\`, so transitive shape doesn't leak into the published artifact
  - Tag-gated runs are infrequent

If pinning becomes important, a future PR can add \`package-lock.json\` (committed alongside \`bun.lock\`) and switch back to \`npm ci\`. Not needed today.

## Post-merge: re-tag v1.1.4

The existing \`v1.1.4\` tag points at the pre-fix commit, so its workflow run can't pick up the fix. After this PR merges:

\`\`\`bash
git tag -d v1.1.4
git push origin :v1.1.4    # delete remote tag
git tag v1.1.4              # retag at new HEAD on main
git push origin v1.1.4      # retrigger publish workflow
\`\`\`

No external systems have picked up the broken v1.1.4 yet — \`npm view @orcarouter/mcp version\` still shows 1.1.3, MCP Registry still has 1.1.3 active. Tag rewrite is safe.

## Test plan

- [x] YAML parses
- [ ] After merge + re-tag, watch the new workflow run succeed at the npm publish step