### PR TITLE
chore(release): v1.1.5 — add static tools[] to MCPB manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `@orcarouter/mcp` follow the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.5
+
+### Changed
+
+- **MCPB `manifest.json` now lists tools statically.** Added a `tools` array
+  enumerating the four MCP tools (`orcarouter_chat`, `orcarouter_models_list`,
+  `orcarouter_model_card`, `orcarouter_providers_list`) with their names and
+  descriptions. Flipped `tools_generated` from `true` to `false` since we
+  don't add tools at runtime — the four are exhaustive.
+
+  Directory sites that read `manifest.json` (Smithery, Anthropic Connectors
+  Directory) couldn't list our capabilities before because they only saw
+  `tools_generated: true` with no static `tools[]` — they have no way to
+  run a stdio server to introspect. Smithery's API tab was showing
+  "No capabilities found"; this lands the static list directory crawlers
+  need.
+
+  No wire-level change. Runtime tool discovery via the MCP `tools/list`
+  method is unchanged — that's what MCP clients (Claude Desktop, Cursor,
+  Windsurf, …) still use at connect time.
+
 ## v1.1.4
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "orcarouter-mcp",
   "display_name": "OrcaRouter",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Browse 160+ LLM models with live pricing — no API key needed for catalog. Route chat completions through OrcaRouter with automatic fallback.",
   "long_description": "OrcaRouter MCP exposes the OrcaRouter LLM gateway (OpenAI-compatible, 160+ models from OpenAI, Anthropic, Google, Qwen, DeepSeek, etc.) as 4 MCP tools.\n\n**Catalog tools** (no API key required):\n- `orcarouter_models_list` — browse models with live pricing, context window, capabilities\n- `orcarouter_model_card` — per-model detail (pricing, latency, modalities, endpoints)\n- `orcarouter_providers_list` — list providers and model counts\n\n**Chat** (API key required):\n- `orcarouter_chat` — single-turn chat with optional fallback chain (up to 5 models, automatic retry on failure)\n\nFor OpenAI reasoning models (gpt-5/o1/o3/...), `max_tokens` is automatically routed to `max_completion_tokens` at the wire level. The MCP server speaks the standard 2025-06-18 protocol revision over stdio.",
   "author": {
@@ -40,7 +40,25 @@
       "required": false
     }
   },
-  "tools_generated": true,
+  "tools": [
+    {
+      "name": "orcarouter_models_list",
+      "description": "List 160+ LLM models with live pricing, context window, and capabilities. Filter by provider, capability, or minimum context. No API key required."
+    },
+    {
+      "name": "orcarouter_model_card",
+      "description": "Detailed info for one model: pricing, max output, modalities, supported endpoints, latency p50/p95. No API key required."
+    },
+    {
+      "name": "orcarouter_providers_list",
+      "description": "List providers with model counts. No API key required."
+    },
+    {
+      "name": "orcarouter_chat",
+      "description": "Single-turn chat with optional fallback chain (up to 5 models, automatic retry on failure). For OpenAI reasoning models (gpt-5/o1/o3), max_tokens auto-translates to max_completion_tokens. API key required."
+    }
+  ],
+  "tools_generated": false,
   "compatibility": {
     "claude_desktop": ">=1.0.0",
     "platforms": ["darwin", "win32", "linux"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/mcp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "mcpName": "io.github.Continuum-AI-Corp/orcarouter-mcp",
   "description": "Official Model Context Protocol server for OrcaRouter — an OpenAI-compatible LLM API gateway.",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/Continuum-AI-Corp/orcarouter-mcp-server",
     "source": "github"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@orcarouter/mcp",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

Smithery's listing for OrcaRouter (https://smithery.ai/servers/continuum-ai-corp/orcarouter-mcp) shows **"No capabilities found"** under its API tab. Score 60/100. Root cause verified against the MCPB spec:

> `tools`: Array of tools the extension provides.
> `tools_generated`: Boolean indicating the server generates **additional** tools at runtime (default: false).

Our v1.1.4 `manifest.json` shipped with `tools_generated: true` and no `tools[]` — meaning "ZERO known tools, possibly additional at runtime". Directory sites that read MCPB manifests can't run stdio servers to introspect, so they see no capabilities. Same issue will hit Anthropic Connectors Directory.

## Fix

```diff
+ "tools": [
+   { "name": "orcarouter_models_list", "description": "..." },
+   { "name": "orcarouter_model_card", "description": "..." },
+   { "name": "orcarouter_providers_list", "description": "..." },
+   { "name": "orcarouter_chat", "description": "..." }
+ ],
- "tools_generated": true,
+ "tools_generated": false,
```

The four are exhaustive — we never add tools at runtime — so `tools_generated: false` (the default) is correct.

## Verification

- [x] `mcpb validate manifest.json` — schema passes
- [x] `server.json valid` against the official Registry schema
- [x] Versions 5-way consistent (tag `v1.1.5` / `package.json` / `server.json` / `server.json.packages[0]` / `manifest.json` all `1.1.5`)
- [x] `npm run typecheck` clean
- [x] `npm test` 116/116 pass
- [x] `npm run build` clean (`dist/index.js` 26.51 KB)
- [x] `npm run pack:mcpb` produces `orcarouter-mcp-1.1.5.mcpb`; unpacked manifest shows `tools_size: 4`, `tools_generated: false`, all 4 tool names present

## No wire-level change

Runtime MCP `tools/list` is unchanged — what MCP clients (Claude Desktop, Cursor, Windsurf, …) actually call at connect time still returns the full schemas from `src/server.ts`. This PR only changes the static `manifest.json` inside the `.mcpb` bundle, used by directory crawlers for display.

## Release plan

After merge:

```bash
git checkout main && git pull
git tag v1.1.5
git push origin v1.1.5
# CI: typecheck → test → build → npm publish → mcp-publisher publish → build .mcpb → attach to GitHub Release
```

Then re-publish to Smithery so the listing reflects the new bundle:

```bash
smithery mcp publish \
  orcarouter-mcp-1.1.5.mcpb \
  -n continuum-ai-corp/orcarouter-mcp
```

(Download the .mcpb from the v1.1.5 GitHub Release once CI completes.)

## Out of scope

- README Smithery badge — that's PR #14 (a separate concern, no version impact).